### PR TITLE
Fix BBDown 1.6.3 compatibility issues

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -21,10 +21,15 @@ source ~/.bashrc  # 或 ~/.zshrc
 
 ### 2. 初始化 skill 环境
 
+**先切换到本 skill 的目录**，然后初始化：
+
 ```bash
-cd ~/.agents/skills/bilibili-subtitle
+# 进入 skill 目录（根据你的安装位置调整）
+cd <skill目录>
 pixi install  # 安装 Python 依赖
 ```
+
+> skill 目录位置：`~/.agents/skills/bilibili-subtitle` 或 `~/.claude/skills/bilibili-subtitle`
 
 ### 3. 安装外部工具
 
@@ -55,7 +60,7 @@ BBDown logined  # 查看登录状态
 **⚠️ 重要：所有命令必须在 skill 目录下运行，并确保 PATH 包含 pixi 和 BBDown**
 
 ```bash
-cd ~/.agents/skills/bilibili-subtitle
+cd <skill目录>
 export PATH="$HOME/.pixi/bin:$HOME/.local/bin:$PATH"
 ```
 
@@ -203,9 +208,9 @@ output/
 如果上述前置依赖都未安装，可运行一键安装脚本：
 
 ```bash
-cd ~/.agents/skills/bilibili-subtitle
+cd <skill目录>
 ./install.sh  # 会尝试安装 pixi + Python 依赖 + BBDown
-BBDown login  # 扫码登录
+BBDown login  # 扫码登录，已登录则跳过
 ```
 
 ## 详细文档

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,11 +39,15 @@ chmod +x ~/.local/bin/BBDown
 BBDown login  # 扫码登录
 ```
 
-### 4. 验证环境
+### 4. 登录 B站（首次使用时）
 
 ```bash
-cd ~/.agents/skills/bilibili-subtitle
-pixi run python -m bilibili_subtitle --check
+BBDown login  # 扫码登录，已登录则跳过
+```
+
+**检测是否已登录**：
+```bash
+BBDown logined  # 查看登录状态
 ```
 
 ## Quick Reference

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,52 @@ user-invocable: true
 
 从 Bilibili 视频提取字幕，支持 AI 字幕检测和 ASR 转录回退。
 
+## ⚠️ 前置依赖（必须先安装）
+
+本 skill 使用 **pixi** 作为 Python 环境管理器。所有命令都需要在 skill 目录下运行。
+
+### 1. 安装 pixi（如果尚未安装）
+
+```bash
+curl -fsSL https://pixi.sh/install.sh | bash
+source ~/.bashrc  # 或 ~/.zshrc
+```
+
+### 2. 初始化 skill 环境
+
+```bash
+cd ~/.agents/skills/bilibili-subtitle
+pixi install  # 安装 Python 依赖
+```
+
+### 3. 安装外部工具
+
+```bash
+# BBDown（B站下载工具）
+mkdir -p ~/.local/bin
+curl -L "https://github.com/nilaoda/BBDown/releases/download/1.6.3/BBDown_1.6.3_20240814_osx-arm64.zip" -o /tmp/bbdown.zip
+unzip -o /tmp/bbdown.zip -d ~/.local/bin
+chmod +x ~/.local/bin/BBDown
+
+# 登录 B站
+BBDown login  # 扫码登录
+```
+
+### 4. 验证环境
+
+```bash
+cd ~/.agents/skills/bilibili-subtitle
+pixi run python -m bilibili_subtitle --check
+```
+
 ## Quick Reference
+
+**⚠️ 重要：所有命令必须在 skill 目录下运行，并确保 PATH 包含 pixi 和 BBDown**
+
+```bash
+cd ~/.agents/skills/bilibili-subtitle
+export PATH="$HOME/.pixi/bin:$HOME/.local/bin:$PATH"
+```
 
 | 任务 | 命令 |
 |------|------|
@@ -149,11 +194,13 @@ output/
 | `ANTHROPIC_API_KEY` | Anthropic | 校对/摘要 | 推荐 |
 | `DASHSCOPE_API_KEY` | 阿里云 | ASR 转录 | 无字幕时必需 |
 
-## 安装
+## 安装（完整流程）
+
+如果上述前置依赖都未安装，可运行一键安装脚本：
 
 ```bash
 cd ~/.agents/skills/bilibili-subtitle
-./install.sh
+./install.sh  # 会尝试安装 pixi + Python 依赖 + BBDown
 BBDown login  # 扫码登录
 ```
 

--- a/bilibili_subtitle/bbdown_client.py
+++ b/bilibili_subtitle/bbdown_client.py
@@ -123,9 +123,13 @@ class BBDownClient:
         raise last_exc or BBDownError("BBDown failed after retries")
 
     def get_video_info(
-        self, url: str, work_dir: Path, *, lang: str | None = "zh-Hans"
+        self, url: str, work_dir: Path, *, lang: str | None = None
     ) -> VideoInfo:
-        """Download subtitles and return video info (Fix 4, 7)."""
+        """Download subtitles and return video info.
+
+        Note: BBDown 1.6.3 does not support --select-lang with zh-Hans format.
+        We use --skip-ai=false to include AI-generated subtitles.
+        """
         work_dir.mkdir(parents=True, exist_ok=True)
         video_id = self._extract_video_id(url)
 
@@ -133,18 +137,17 @@ class BBDownClient:
             work_dir.glob(f"{video_id}*.vtt")
         )
 
+        # Build args - use --skip-ai=false to download AI subtitles
+        # Note: BBDown default is --skip-ai (skip AI subtitles)
         args = self._base_args() + [
             "--sub-only",
-            "--skip-ai",
-            "false",
+            "--skip-ai=false",
             "-F",
             video_id,
             "--work-dir",
             str(work_dir),
+            url,
         ]
-        if lang is not None:
-            args += ["--select-lang", lang]
-        args.append(url)
 
         result = self._run(args, check=False)
         output = result.stdout + result.stderr

--- a/bilibili_subtitle/preflight.py
+++ b/bilibili_subtitle/preflight.py
@@ -123,35 +123,55 @@ def check_bbdown() -> CheckResult:
 
 
 def check_bbdown_auth() -> CheckResult:
-    bbdown_data = Path.home() / "BBDown.data"
-    if bbdown_data.exists():
-        try:
-            content = bbdown_data.read_text()
-            has_sessdata = "SESSDATA" in content
-            if has_sessdata:
+    """Check BBDown authentication by looking for cookie file.
+
+    BBDown stores cookies in BBDown.data file, which can be in:
+    - ~/.local/bin/BBDown.data (when installed manually)
+    - ~/BBDown.data (when installed via install.sh)
+    - Same directory as BBDown binary
+    """
+    # Possible locations for BBDown.data
+    possible_paths = [
+        Path.home() / ".local" / "bin" / "BBDown.data",
+        Path.home() / "BBDown.data",
+    ]
+
+    # Also check in the same directory as BBDown binary
+    bbdown_path = shutil.which("BBDown")
+    if bbdown_path:
+        possible_paths.append(Path(bbdown_path).parent / "BBDown.data")
+
+    # Also check AppDirectory (BBDown's default location)
+    # BBDown logs show: AppDirectory: /Users/aidis/.local/bin
+    for path in possible_paths:
+        if path.exists():
+            try:
+                content = path.read_text()
+                has_sessdata = "SESSDATA" in content
+                if has_sessdata:
+                    return CheckResult(
+                        name="BBDown Auth",
+                        status=CheckStatus.OK,
+                        message="Logged in",
+                        details={"cookie_file": str(path)},
+                    )
                 return CheckResult(
                     name="BBDown Auth",
-                    status=CheckStatus.OK,
-                    message="Logged in",
-                    details={"cookie_file": str(bbdown_data)},
+                    status=CheckStatus.ERROR,
+                    message=f"Cookie file exists at {path} but no SESSDATA",
+                    remediation="Run: BBDown login",
                 )
-            return CheckResult(
-                name="BBDown Auth",
-                status=CheckStatus.ERROR,
-                message="Cookie file exists but no SESSDATA",
-                remediation="Run: BBDown login",
-            )
-        except Exception as e:
-            return CheckResult(
-                name="BBDown Auth",
-                status=CheckStatus.WARNING,
-                message=f"Cannot read cookie file: {e}",
-                remediation="Run: BBDown login",
-            )
+            except Exception as e:
+                return CheckResult(
+                    name="BBDown Auth",
+                    status=CheckStatus.WARNING,
+                    message=f"Cannot read cookie file: {e}",
+                    remediation="Run: BBDown login",
+                )
     return CheckResult(
         name="BBDown Auth",
         status=CheckStatus.ERROR,
-        message="Not logged in",
+        message="Not logged in (no BBDown.data found)",
         remediation="Run: BBDown login",
     )
 


### PR DESCRIPTION
## Summary

Fixes #4 

Two compatibility issues with BBDown 1.6.3:

### Fix 1: bbdown_client.py
- Remove unsupported  parameter (BBDown 1.6.3 doesn't support this format)
- Use  as single argument instead of split 

### Fix 2: preflight.py  
- Check BBDown.data in multiple possible locations:
  -  (manual install)
  -  (install.sh)
  - Same directory as BBDown binary

## Test Results

All test videos successfully extracted subtitles after the fix:
- BV1mgLU69Eii: 我删了 100 个复杂策略，留下了这个最能打的 ✓
- BV1pS5w6mEVU: 我烧了70 亿Token 后做了一个10K Star开源项目 ✓
- BV1wMGd6bEA4: 有趣的Linux学习方式 ✓
- BV1A7V36BEc9: 内存暴涨，谁在哭？谁在笑？ ✓

## Files Changed

- : Fixed command arguments
- : Fixed cookie file location detection

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)